### PR TITLE
Expand Terraform IAM and CI setup

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -47,3 +47,20 @@ variable "scheduler_tz" {
   type    = string
   default = "America/New_York"
 }
+
+# Workload Identity Federation
+variable "wif_pool_id" {
+  type    = string
+  default = "mlb-ci-pool"
+}
+
+variable "wif_provider_id" {
+  type    = string
+  default = "mlb-github"
+}
+
+variable "github_repository" {
+  type        = string
+  description = "GitHub repository in owner/name format for OIDC trust"
+  default     = "OWNER/REPO"
+}


### PR DESCRIPTION
## Summary
- Split ingest and digest runtime identities with dataset-scoped BigQuery access
- Add CI service account with Cloud Run, Workflows, and Artifact Registry privileges
- Configure GitHub Workload Identity Federation and allow Scheduler to impersonate its SA
- Correct BigQuery dataset IAM and extend Workflow custom role with operation permissions

------
https://chatgpt.com/codex/tasks/task_e_68b15c92b800832cab2258040479863c