### PR TITLE
Add run.viewer binding for workflow service account

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -63,7 +63,7 @@ Cloud Scheduler triggers the Workflow on a schedule:
 | ----------- | -------------------------------------------------- | ---------------------------------------------- |
 | CI SA       | `roles/run.admin`, `roles/workflows.admin`         | Update Cloud Run jobs, deploy/update Workflows |
 |             | `roles/artifactregistry.writer` _(scoped to repo)_ | Push images to Artifact Registry               |
-| Workflow SA | _(optional)_ `roles/logging.logWriter`             | Allow Workflow to write logs                   |
+| Workflow SA | `roles/run.viewer`, _(optional)_ `roles/logging.logWriter` | View Cloud Run jobs; allow Workflow to write logs |
 
 ---
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -149,6 +149,11 @@ resource "google_project_iam_member" "wf_run_job_runner" {
   role    = google_project_iam_custom_role.run_job_runner_with_overrides.name
   member  = "serviceAccount:${google_service_account.wf.email}"
 }
+resource "google_project_iam_member" "wf_run_viewer" {
+  project = var.project_id
+  role    = "roles/run.viewer"
+  member  = "serviceAccount:${google_service_account.wf.email}"
+}
 resource "google_project_iam_member" "wf_logs" {
   project = var.project_id
   role    = "roles/logging.logWriter"


### PR DESCRIPTION
## Summary
- grant the Workflow service account `roles/run.viewer` via Terraform
- document the new project-level role for the Workflow SA

Ran `pytest`; Terraform CLI unavailable so `terraform fmt` and `terraform validate` could not be executed.

------
https://chatgpt.com/codex/tasks/task_e_68b1b2d1b448832cb6a672c52290d9e7